### PR TITLE
Prevent grade offset for post grad

### DIFF
--- a/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
+++ b/cc_newspring/AttendedCheckin/ActivitySelect.ascx.cs
@@ -977,7 +977,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                     ddlSuffix.SelectedValue = person.Person.SuffixValueId.ToString();
                 }
 
-                if ( person.Person.GradeOffset.HasValue )
+                if ( person.Person.GradeOffset.HasValue && person.Person.GradeOffset.Value >= 0 )
                 {
                     ddlAbilityGrade.SelectedValue = person.Person.GradeOffset.ToString();
                 }


### PR DESCRIPTION
Don't populate the grade offset if selected person has already completed high school as it will throw an error and prevent the edit form from displaying.