### PR TITLE
Ensure restricted location assignments don't get rebalanced

### DIFF
--- a/Workflow/Action/CheckIn/SelectByMultipleAttended.cs
+++ b/Workflow/Action/CheckIn/SelectByMultipleAttended.cs
@@ -165,7 +165,7 @@ namespace cc.newspring.AttendedCheckIn.Workflow.Action.CheckIn
                                     group = groupType.Groups.FirstOrDefault( g => g.Group.Id == groupAttendance.GroupId && ( !g.ExcludedByFilter || useCheckinOverride ) );
 
                                     // Room balance only on new check-ins
-                                    if ( group != null && roomBalanceGroupTypeIds.Contains( group.Group.GroupTypeId ) && !useCheckinOverride )
+                                    if ( group != null && roomBalanceGroupTypeIds.Contains( group.Group.GroupTypeId ) && !excludedLocations.Contains( g.Group.Name ) && !useCheckinOverride )
                                     {
                                         // Make sure balanced rooms are open for the current service
                                         var currentAttendance = group.Locations.Where( l => l.AvailableForSchedule.Contains( schedule.Schedule.Id ) )
@@ -198,7 +198,7 @@ namespace cc.newspring.AttendedCheckIn.Workflow.Action.CheckIn
                                         location = group.Locations.FirstOrDefault( l => l.Location.Id == groupAttendance.LocationId && ( !l.ExcludedByFilter || useCheckinOverride ) );
 
                                         // Room balance only on new check-ins
-                                        if ( location != null && roomBalanceGroupTypeIds.Contains( group.Group.GroupTypeId ) && !useCheckinOverride )
+                                        if ( location != null && roomBalanceGroupTypeIds.Contains( group.Group.GroupTypeId ) && !excludedLocations.Contains( g.Group.Name ) && !useCheckinOverride )
                                         {
                                             var currentAttendance = Helpers.ReadAttendanceBySchedule( location.Location.Id, schedule.Schedule.Id );
 


### PR DESCRIPTION
Waiting on feedback from @FrankGrand.  Assignments are never balanced _to_ a restricted location, but could be balanced away from one.