### PR TITLE
Fix tag printing and "checked-in" status

### DIFF
--- a/Workflow/Action/CheckIn/SelectByBestFit.cs
+++ b/Workflow/Action/CheckIn/SelectByBestFit.cs
@@ -285,7 +285,7 @@ namespace cc.newspring.AttendedCheckIn.Workflow.Action.CheckIn
                                     if ( bestGroup != null && roomBalanceGroupTypeIds.Contains( bestGroup.Group.GroupTypeId ) )
                                     {
                                         int? bestScheduleId = null;
-                                        var availableSchedules = validGroups.SelectMany( g => g.Locations.SelectMany( l => l.Schedules ) ).ToList();
+                                        var availableSchedules = validGroups.SelectMany( g => g.Locations.SelectMany( l => l.Schedules ) ).DistinctBy( s => s.Schedule.Id ).ToList();
                                         if ( availableSchedules.Any() )
                                         {
                                             bestScheduleId = availableSchedules.OrderBy( s => s.StartTime ).Select( s => s.Schedule.Id ).FirstOrDefault();
@@ -329,8 +329,7 @@ namespace cc.newspring.AttendedCheckIn.Workflow.Action.CheckIn
                                     if ( roomBalanceGroupTypeIds.Contains( bestGroup.Group.GroupTypeId ) )
                                     {
                                         int? bestScheduleId = null;
-                                        var availableSchedules = filteredLocations.SelectMany( l => l.Schedules )
-                                            .DistinctBy( s => s.Schedule.Id ).ToList();
+                                        var availableSchedules = filteredLocations.SelectMany( l => l.Schedules ).DistinctBy( s => s.Schedule.Id ).ToList();
                                         if ( availableSchedules.Any() )
                                         {
                                             bestScheduleId = availableSchedules.OrderBy( s => s.StartTime ).Select( s => s.Schedule.Id ).FirstOrDefault();

--- a/Workflow/Action/CheckIn/SelectByMultipleAttended.cs
+++ b/Workflow/Action/CheckIn/SelectByMultipleAttended.cs
@@ -144,7 +144,7 @@ namespace cc.newspring.AttendedCheckIn.Workflow.Action.CheckIn
                                 else if ( currentlyCheckedIn )
                                 {
                                     // always pick the schedule they're currently checked into
-                                    currentScheduleId = orderedSchedules.Where( s => currentScheduleId == groupAttendance.ScheduleId ).FirstOrDefault();
+                                    currentScheduleId = orderedSchedules.Where( s => s == groupAttendance.ScheduleId ).FirstOrDefault();
                                 }
                                 else
                                 {

--- a/cc_newspring/AttendedCheckin/Confirm.ascx.cs
+++ b/cc_newspring/AttendedCheckin/Confirm.ascx.cs
@@ -444,7 +444,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 List<CheckInLocation> availableLocations = null;
                 List<CheckInSchedule> availableSchedules = null;
                 List<CheckInSchedule> possiblePersonSchedules = null;
-                var backupSchedules = selectedGroupTypes.Select( gt => new { gt.GroupType.Id, gt.SelectedForSchedule } ).ToList();
+                //var backupSchedules = selectedGroupTypes.Select( gt => new { gt.GroupType.Id, gt.SelectedForSchedule } ).ToList();
 
                 foreach ( DataKey dataKey in checkinArray )
                 {
@@ -472,7 +472,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
 
                         // Unselect the SelectedSchedule properties too
                         possiblePersonSchedules.ForEach( s => s.Selected = ( s.Schedule.Id == scheduleId ) );
-                        selectedGroupTypes.ForEach( gt => gt.SelectedForSchedule.RemoveAll( s => s != scheduleId ) );
+                        //selectedGroupTypes.ForEach( gt => gt.SelectedForSchedule.RemoveAll( s => s != scheduleId ) );
                     }
 
                     // Create labels for however many items are currently selected
@@ -588,15 +588,15 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                     availableSchedules.ForEach( s => s.Selected = s.PreSelected );
 
                     // use the backup to reset groupType.AvailableForSchedule
-                    for ( int i = 0; i < selectedGroupTypes.Count; i++ )
-                    {
-                        var groupType = selectedGroupTypes.ElementAtOrDefault( i );
-                        var backup = backupSchedules.ElementAtOrDefault( i );
-                        if ( groupType != null && backup != null )
-                        {
-                            groupType.SelectedForSchedule = backup.SelectedForSchedule;
-                        }
-                    }
+                    //for ( int i = 0; i < selectedGroupTypes.Count; i++ )
+                    //{
+                    //    var groupType = selectedGroupTypes.ElementAtOrDefault( i );
+                    //    var backup = backupSchedules.ElementAtOrDefault( i );
+                    //    if ( groupType != null && backup != null )
+                    //    {
+                    //        groupType.SelectedForSchedule = backup.SelectedForSchedule;
+                    //    }
+                    //}
                 }
 
                 // since Save Attendance already ran, mark everyone as being checked in

--- a/cc_newspring/AttendedCheckin/Confirm.ascx.cs
+++ b/cc_newspring/AttendedCheckin/Confirm.ascx.cs
@@ -444,7 +444,6 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                 List<CheckInLocation> availableLocations = null;
                 List<CheckInSchedule> availableSchedules = null;
                 List<CheckInSchedule> possiblePersonSchedules = null;
-                //var backupSchedules = selectedGroupTypes.Select( gt => new { gt.GroupType.Id, gt.SelectedForSchedule } ).ToList();
 
                 foreach ( DataKey dataKey in checkinArray )
                 {
@@ -471,8 +470,7 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                         availableSchedules.ForEach( s => s.Selected = ( s.Schedule.Id == scheduleId ) );
 
                         // Unselect the SelectedSchedule properties too
-                        possiblePersonSchedules.ForEach( s => s.Selected = ( s.Schedule.Id == scheduleId ) );
-                        //selectedGroupTypes.ForEach( gt => gt.SelectedForSchedule.RemoveAll( s => s != scheduleId ) );
+                        possiblePersonSchedules.ForEach( s => s.Selected = ( s.Schedule.Id == scheduleId ) )
                     }
 
                     // Create labels for however many items are currently selected
@@ -586,17 +584,6 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
                     availableGroups.ForEach( g => g.Selected = g.PreSelected );
                     availableLocations.ForEach( l => l.Selected = l.PreSelected );
                     availableSchedules.ForEach( s => s.Selected = s.PreSelected );
-
-                    // use the backup to reset groupType.AvailableForSchedule
-                    //for ( int i = 0; i < selectedGroupTypes.Count; i++ )
-                    //{
-                    //    var groupType = selectedGroupTypes.ElementAtOrDefault( i );
-                    //    var backup = backupSchedules.ElementAtOrDefault( i );
-                    //    if ( groupType != null && backup != null )
-                    //    {
-                    //        groupType.SelectedForSchedule = backup.SelectedForSchedule;
-                    //    }
-                    //}
                 }
 
                 // since Save Attendance already ran, mark everyone as being checked in


### PR DESCRIPTION
@jbaxleyiii TL;DR we lose consistency with the object tree state.  There's no immediate impact or visibility (except when debugging).

The long explanation:
Check-in selections are stored in an object tree as follows:
Family -> Person -> GroupType(s) -> Group(s) -> Location(s) -> Schedule(s)

In every check-in object/model, the boolean property `Selected` and `PreSelected` are used to designate what's been selected for check-in.  Rock v6 added two new fields `AvailableForSchedule` and `SelectedForSchedule` that tracks if a particular schedule is available for that model or selected for that model.

The [CreateLabels](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock/Workflow/Action/CheckIn/CreateLabels.cs) workflow action now depends on `[model].Selected` or `[model].SelectedForSchedule` to generate the correct labels.  However, the Person.GroupTypes lookup is inconsistent -- it ignores `groupType.Selected` and only returns labels for `grouptype.SelectedForSchedule`.  See https://github.com/SparkDevNetwork/Rock/pull/1932 for more details.

Because we print individual labels and not all-in-one labels, we have to unmark tree selections to only process one label at a time.  That means the object tree is fluctuating during each label's generation, but needs to be restored with everyone's selections at the end.

The code I removed was trying to verify that `groupType.SelectedForSchedule` was always identical to the selections marked in the object tree (but wasn't working as of this morning).