### PR TITLE
Fix Age Showing on Confirm Page

### DIFF
--- a/cc_newspring/AttendedCheckin/Confirm.ascx.cs
+++ b/cc_newspring/AttendedCheckin/Confirm.ascx.cs
@@ -191,7 +191,8 @@ namespace RockWeb.Plugins.cc_newspring.AttendedCheckin
 
                 if ( !checkInList.Any( c => c.PersonId == person.Person.Id ) )
                 {   // auto assignment didn't select anything
-                    checkInList.Add( new Activity { PersonId = person.Person.Id, Name = person.Person.FullName, GroupId = 0, LocationId = 0, ScheduleId = 0 } );
+                    var personsAge = person.Person.Age < 18 ? person.Person.Age.ToStringSafe() : string.Empty;
+                    checkInList.Add( new Activity { PersonId = person.Person.Id, Name = person.Person.FullName, Age = personsAge, GroupId = 0, LocationId = 0, ScheduleId = 0 } );
                 }
             }
 


### PR DESCRIPTION
*Feature/Fix*
- Fixed the confirmation page to allow the age to always show, regardless of whether or not an assignment was created.

Before:
![screenshot 2017-04-30 16 22 22](https://cloud.githubusercontent.com/assets/3229463/25567688/780e5a38-2dc1-11e7-9833-a8acc7848d0c.png)

After:
![screenshot 2017-04-30 16 23 26](https://cloud.githubusercontent.com/assets/3229463/25567689/7ed7050e-2dc1-11e7-91f2-d070a181a10f.png)
